### PR TITLE
Expose self-hosted Nest fan timer control in HomeKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Expose a HomeKit fan service for self-hosted thermostats that report fan capability.
+- Map HomeKit fan On/Off to NLE's timed fan On/Auto control while reporting the actual blower state separately.
+
 All notable changes to this project will be documented in this file.
 
 ## [1.2.2] - 2026-06-28

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ NoLongerEvil is a project that revives bricked or abandoned Nest Gen 1 & 2 therm
 - **Thermostat Control** — Set target temperature, switch between heating, cooling, auto, and off modes
 - **Temperature Range** — Set heating and cooling thresholds for auto mode
 - **Humidity Sensor** — View current relative humidity
+- **Fan Control** — Start a timed fan cycle or return the fan to automatic control (self-hosted thermostats with fan capability)
 - **Smart Schedule Switch** — Enable or disable the Nest's built-in schedule from HomeKit
 - **Schedule Editor** — View and edit the weekly thermostat schedule from the Homebridge UI
 - **Learning Mode Control** — Automatically disables the Nest's auto-schedule learning when the smart schedule is turned off (self-hosted)
@@ -125,7 +126,16 @@ Each thermostat appears in HomeKit with:
 
 - **Thermostat** — Current temperature, target temperature, HVAC mode (Off / Heat / Cool / Auto), and heating/cooling thresholds for auto mode
 - **Humidity Sensor** — Current relative humidity
+- **Fan** — Start a timed fan cycle, return to automatic control, and view whether the blower is currently running (self-hosted only)
 - **Smart Schedule Switch** — Toggle the Nest's built-in schedule on or off
+
+### Fan Control
+
+For self-hosted NLE servers, thermostats that report `has_fan` expose a separate
+HomeKit fan service. Turning it on starts NLE's configured fan timer (60 minutes
+by default); turning it off returns the thermostat to automatic fan control.
+HomeKit also reports the blower's current running state independently from the
+timer setting.
 
 ### Smart Schedule Switch
 

--- a/dist/api.d.ts
+++ b/dist/api.d.ts
@@ -33,6 +33,9 @@ export interface ThermostatState {
     awayMode: boolean;
     canHeat: boolean;
     canCool: boolean;
+    hasFan: boolean;
+    fanActive: boolean;
+    fanRunning: boolean;
     name: string;
 }
 export interface ScheduleEntry {
@@ -66,7 +69,9 @@ export interface ThermostatApiClient {
     setSchedule(deviceId: string, schedule: ThermostatSchedule): Promise<void>;
     clearSchedule(deviceId: string): Promise<void>;
     setLearningMode(deviceId: string, enabled: boolean): Promise<void>;
+    setFanActive(deviceId: string, active: boolean): Promise<void>;
     readonly supportsLearningMode: boolean;
+    readonly supportsFanControl: boolean;
     readonly sourceLabel: string;
 }
 export declare const RETRYABLE_STATUS: Set<number>;
@@ -90,6 +95,7 @@ export declare class NoLongerEvilAPI implements ThermostatApiClient {
     constructor(apiKey: string, log: Logger, serverUrl?: string);
     get sourceLabel(): string;
     get supportsLearningMode(): boolean;
+    get supportsFanControl(): boolean;
     private request;
     private requestOnce;
     getDevices(): Promise<ApiDevice[]>;
@@ -101,7 +107,8 @@ export declare class NoLongerEvilAPI implements ThermostatApiClient {
     getSchedule(deviceId: string): Promise<ThermostatSchedule | null>;
     setSchedule(deviceId: string, schedule: ThermostatSchedule): Promise<void>;
     clearSchedule(deviceId: string): Promise<void>;
-    setLearningMode(_deviceId: string, _enabled: boolean): Promise<void>;
+    setLearningMode(deviceId: string, enabled: boolean): Promise<void>;
+    setFanActive(deviceId: string, active: boolean): Promise<void>;
     parseDeviceStatus(deviceId: string, response: DeviceStatusResponse): ThermostatState;
     getThermostatStates(): Promise<ThermostatState[]>;
     getThermostatState(deviceId: string): Promise<ThermostatState | null>;

--- a/dist/api.js
+++ b/dist/api.js
@@ -88,6 +88,9 @@ class NoLongerEvilAPI {
     get supportsLearningMode() {
         return false;
     }
+    get supportsFanControl() {
+        return false;
+    }
     async request(method, path, body) {
         for (let attempt = 0;; attempt++) {
             try {
@@ -211,8 +214,15 @@ class NoLongerEvilAPI {
         };
         await this.request('PUT', `/thermostat/${deviceId}/schedule`, { schedule: emptySchedule });
     }
-    async setLearningMode(_deviceId, _enabled) {
+    async setLearningMode(deviceId, enabled) {
+        void deviceId;
+        void enabled;
         this.log.warn('Learning mode control is not available on the hosted API');
+    }
+    async setFanActive(deviceId, active) {
+        void deviceId;
+        void active;
+        this.log.warn('Fan control is not available on the hosted API');
     }
     parseDeviceStatus(deviceId, response) {
         const serial = response.device.serial;
@@ -273,6 +283,9 @@ class NoLongerEvilAPI {
             awayMode,
             canHeat,
             canCool,
+            hasFan: false,
+            fanActive: false,
+            fanRunning: false,
             name,
         };
     }

--- a/dist/selfHostedApi.d.ts
+++ b/dist/selfHostedApi.d.ts
@@ -9,12 +9,13 @@ export declare class SelfHostedAPI implements ThermostatApiClient {
     constructor(apiKey: string, serverUrl: string, log: Logger);
     get sourceLabel(): string;
     get supportsLearningMode(): boolean;
+    get supportsFanControl(): boolean;
     private request;
     private requestOnce;
     getThermostatStates(): Promise<ThermostatState[]>;
     getThermostatState(deviceId: string): Promise<ThermostatState | null>;
     private parseDevice;
-    setTemperature(deviceId: string, temperature: number, _mode: 'heat' | 'cool'): Promise<void>;
+    setTemperature(deviceId: string, temperature: number, mode: 'heat' | 'cool'): Promise<void>;
     setTemperatureRange(deviceId: string, lowTemperature: number, highTemperature: number): Promise<void>;
     setMode(deviceId: string, mode: 'off' | 'heat' | 'cool' | 'heat-cool'): Promise<void>;
     setAwayMode(deviceId: string, away: boolean): Promise<void>;
@@ -22,4 +23,5 @@ export declare class SelfHostedAPI implements ThermostatApiClient {
     setSchedule(deviceId: string, schedule: ThermostatSchedule): Promise<void>;
     clearSchedule(deviceId: string): Promise<void>;
     setLearningMode(deviceId: string, enabled: boolean): Promise<void>;
+    setFanActive(deviceId: string, active: boolean): Promise<void>;
 }

--- a/dist/selfHostedApi.js
+++ b/dist/selfHostedApi.js
@@ -57,6 +57,9 @@ class SelfHostedAPI {
     get supportsLearningMode() {
         return true;
     }
+    get supportsFanControl() {
+        return true;
+    }
     async request(method, path, body) {
         for (let attempt = 0;; attempt++) {
             try {
@@ -206,6 +209,10 @@ class SelfHostedAPI {
         const awayMode = device.away ?? false;
         const canHeat = device.capabilities?.can_heat ?? true;
         const canCool = device.capabilities?.can_cool ?? false;
+        const hasFan = device.capabilities?.has_fan ?? false;
+        const fanActive = device.fan_timer_active === true
+            || (device.fan_timer_timeout ?? 0) > Math.floor(Date.now() / 1000);
+        const fanRunning = device.hvac?.fan ?? false;
         const name = device.name || `Nest ${serial.slice(-4)}`;
         return {
             deviceId: serial,
@@ -220,10 +227,14 @@ class SelfHostedAPI {
             awayMode,
             canHeat,
             canCool,
+            hasFan,
+            fanActive,
+            fanRunning,
             name,
         };
     }
-    async setTemperature(deviceId, temperature, _mode) {
+    async setTemperature(deviceId, temperature, mode) {
+        void mode;
         await this.request('POST', '/command', {
             serial: deviceId,
             command: 'set_temperature',
@@ -295,6 +306,13 @@ class SelfHostedAPI {
         catch (error) {
             this.log.debug('Failed to set learning mode:', error);
         }
+    }
+    async setFanActive(deviceId, active) {
+        await this.request('POST', '/command', {
+            serial: deviceId,
+            command: 'set_fan',
+            value: active ? 'on' : 'auto',
+        });
     }
 }
 exports.SelfHostedAPI = SelfHostedAPI;

--- a/dist/thermostatAccessory.d.ts
+++ b/dist/thermostatAccessory.d.ts
@@ -7,12 +7,14 @@ export declare class NestThermostatAccessory {
     private readonly thermostatService;
     private readonly humidityService;
     private scheduleSwitch?;
+    private fanService?;
     private state;
     private readonly pollInterval;
     private pollTimer?;
     private readonly apiClient;
     private smartScheduleEnabled;
     constructor(platform: NoLongerEvilPlatform, accessory: PlatformAccessory, initialState: ThermostatState, apiClient: ThermostatApiClient);
+    private setupFanService;
     private setupScheduleSwitch;
     private initScheduleState;
     private setSmartSchedule;
@@ -34,4 +36,7 @@ export declare class NestThermostatAccessory {
     getHeatingThresholdTemperature(): CharacteristicValue;
     setHeatingThresholdTemperature(value: CharacteristicValue): Promise<void>;
     getCurrentHumidity(): CharacteristicValue;
+    getFanActive(): CharacteristicValue;
+    getCurrentFanState(): CharacteristicValue;
+    setFanActive(value: CharacteristicValue): Promise<void>;
 }

--- a/dist/thermostatAccessory.js
+++ b/dist/thermostatAccessory.js
@@ -7,6 +7,7 @@ class NestThermostatAccessory {
     thermostatService;
     humidityService;
     scheduleSwitch;
+    fanService;
     state;
     pollInterval;
     pollTimer;
@@ -78,8 +79,26 @@ class NestThermostatAccessory {
         if (this.platform.config.enableScheduleSwitch !== false) {
             this.setupScheduleSwitch();
         }
+        this.setupFanService();
         // Start polling for updates
         this.startPolling();
+    }
+    setupFanService() {
+        const existingFanService = this.accessory.getServiceById(this.platform.Service.Fanv2, 'fan');
+        if (!this.state.hasFan || !this.apiClient.supportsFanControl) {
+            if (existingFanService) {
+                this.accessory.removeService(existingFanService);
+            }
+            return;
+        }
+        this.fanService = existingFanService
+            || this.accessory.addService(this.platform.Service.Fanv2, `${this.state.name} Fan`, 'fan');
+        this.fanService.setCharacteristic(this.platform.Characteristic.Name, `${this.state.name} Fan`);
+        this.fanService.getCharacteristic(this.platform.Characteristic.Active)
+            .onGet(this.getFanActive.bind(this))
+            .onSet(this.setFanActive.bind(this));
+        this.fanService.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+            .onGet(this.getCurrentFanState.bind(this));
     }
     setupScheduleSwitch() {
         if (this.accessory.context.smartScheduleEnabled !== undefined) {
@@ -153,6 +172,8 @@ class NestThermostatAccessory {
         this.thermostatService.updateCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature, this.state.targetTemperatureHigh);
         this.thermostatService.updateCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature, this.state.targetTemperatureLow);
         this.humidityService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.state.humidity);
+        this.fanService?.updateCharacteristic(this.platform.Characteristic.Active, this.getFanActive());
+        this.fanService?.updateCharacteristic(this.platform.Characteristic.CurrentFanState, this.getCurrentFanState());
     }
     mapHvacStateToHomeKit(state) {
         switch (state) {
@@ -278,6 +299,28 @@ class NestThermostatAccessory {
     }
     getCurrentHumidity() {
         return this.state.humidity;
+    }
+    getFanActive() {
+        return this.state.fanActive
+            ? this.platform.Characteristic.Active.ACTIVE
+            : this.platform.Characteristic.Active.INACTIVE;
+    }
+    getCurrentFanState() {
+        return this.state.fanRunning
+            ? this.platform.Characteristic.CurrentFanState.BLOWING_AIR
+            : this.platform.Characteristic.CurrentFanState.INACTIVE;
+    }
+    async setFanActive(value) {
+        const active = value === this.platform.Characteristic.Active.ACTIVE;
+        this.platform.log.info(`Setting ${this.state.name} fan to ${active ? 'on' : 'auto'}`);
+        try {
+            await this.apiClient.setFanActive(this.state.deviceId, active);
+            this.state.fanActive = active;
+        }
+        catch (error) {
+            this.platform.log.error('Failed to set fan mode:', error);
+            throw new this.platform.api.hap.HapStatusError(-70402 /* this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE */);
+        }
     }
 }
 exports.NestThermostatAccessory = NestThermostatAccessory;

--- a/src/api.ts
+++ b/src/api.ts
@@ -40,6 +40,9 @@ export interface ThermostatState {
   awayMode: boolean;
   canHeat: boolean;
   canCool: boolean;
+  hasFan: boolean;
+  fanActive: boolean;
+  fanRunning: boolean;
   name: string;
 }
 
@@ -78,7 +81,9 @@ export interface ThermostatApiClient {
   setSchedule(deviceId: string, schedule: ThermostatSchedule): Promise<void>;
   clearSchedule(deviceId: string): Promise<void>;
   setLearningMode(deviceId: string, enabled: boolean): Promise<void>;
+  setFanActive(deviceId: string, active: boolean): Promise<void>;
   readonly supportsLearningMode: boolean;
+  readonly supportsFanControl: boolean;
   readonly sourceLabel: string;
 }
 
@@ -140,6 +145,10 @@ export class NoLongerEvilAPI implements ThermostatApiClient {
   }
 
   get supportsLearningMode(): boolean {
+    return false;
+  }
+
+  get supportsFanControl(): boolean {
     return false;
   }
 
@@ -297,8 +306,16 @@ export class NoLongerEvilAPI implements ThermostatApiClient {
     await this.request('PUT', `/thermostat/${deviceId}/schedule`, { schedule: emptySchedule });
   }
 
-  async setLearningMode(_deviceId: string, _enabled: boolean): Promise<void> {
+  async setLearningMode(deviceId: string, enabled: boolean): Promise<void> {
+    void deviceId;
+    void enabled;
     this.log.warn('Learning mode control is not available on the hosted API');
+  }
+
+  async setFanActive(deviceId: string, active: boolean): Promise<void> {
+    void deviceId;
+    void active;
+    this.log.warn('Fan control is not available on the hosted API');
   }
 
   parseDeviceStatus(deviceId: string, response: DeviceStatusResponse): ThermostatState {
@@ -368,6 +385,9 @@ export class NoLongerEvilAPI implements ThermostatApiClient {
       awayMode,
       canHeat,
       canCool,
+      hasFan: false,
+      fanActive: false,
+      fanRunning: false,
       name,
     };
   }

--- a/src/selfHostedApi.ts
+++ b/src/selfHostedApi.ts
@@ -29,11 +29,15 @@ interface SelfHostedDevice {
   hvac?: {
     heater?: boolean;
     ac?: boolean;
+    fan?: boolean;
   };
   capabilities?: {
     can_heat?: boolean;
     can_cool?: boolean;
+    has_fan?: boolean;
   };
+  fan_timer_active?: boolean;
+  fan_timer_timeout?: number;
 }
 
 interface DevicesResponse {
@@ -66,6 +70,10 @@ export class SelfHostedAPI implements ThermostatApiClient {
   }
 
   get supportsLearningMode(): boolean {
+    return true;
+  }
+
+  get supportsFanControl(): boolean {
     return true;
   }
 
@@ -240,6 +248,10 @@ export class SelfHostedAPI implements ThermostatApiClient {
     const awayMode = device.away ?? false;
     const canHeat = device.capabilities?.can_heat ?? true;
     const canCool = device.capabilities?.can_cool ?? false;
+    const hasFan = device.capabilities?.has_fan ?? false;
+    const fanActive = device.fan_timer_active === true
+      || (device.fan_timer_timeout ?? 0) > Math.floor(Date.now() / 1000);
+    const fanRunning = device.hvac?.fan ?? false;
     const name = device.name || `Nest ${serial.slice(-4)}`;
 
     return {
@@ -255,11 +267,15 @@ export class SelfHostedAPI implements ThermostatApiClient {
       awayMode,
       canHeat,
       canCool,
+      hasFan,
+      fanActive,
+      fanRunning,
       name,
     };
   }
 
-  async setTemperature(deviceId: string, temperature: number, _mode: 'heat' | 'cool'): Promise<void> {
+  async setTemperature(deviceId: string, temperature: number, mode: 'heat' | 'cool'): Promise<void> {
+    void mode;
     await this.request('POST', '/command', {
       serial: deviceId,
       command: 'set_temperature',
@@ -336,5 +352,13 @@ export class SelfHostedAPI implements ThermostatApiClient {
     } catch (error) {
       this.log.debug('Failed to set learning mode:', error);
     }
+  }
+
+  async setFanActive(deviceId: string, active: boolean): Promise<void> {
+    await this.request('POST', '/command', {
+      serial: deviceId,
+      command: 'set_fan',
+      value: active ? 'on' : 'auto',
+    });
   }
 }

--- a/src/thermostatAccessory.ts
+++ b/src/thermostatAccessory.ts
@@ -10,6 +10,7 @@ export class NestThermostatAccessory {
   private readonly thermostatService: Service;
   private readonly humidityService: Service;
   private scheduleSwitch?: Service;
+  private fanService?: Service;
 
   private state: ThermostatState;
   private readonly pollInterval: number;
@@ -107,8 +108,39 @@ export class NestThermostatAccessory {
       this.setupScheduleSwitch();
     }
 
+    this.setupFanService();
+
     // Start polling for updates
     this.startPolling();
+  }
+
+  private setupFanService(): void {
+    const existingFanService = this.accessory.getServiceById(
+      this.platform.Service.Fanv2,
+      'fan',
+    );
+
+    if (!this.state.hasFan || !this.apiClient.supportsFanControl) {
+      if (existingFanService) {
+        this.accessory.removeService(existingFanService);
+      }
+      return;
+    }
+
+    this.fanService = existingFanService
+      || this.accessory.addService(this.platform.Service.Fanv2, `${this.state.name} Fan`, 'fan');
+
+    this.fanService.setCharacteristic(
+      this.platform.Characteristic.Name,
+      `${this.state.name} Fan`,
+    );
+
+    this.fanService.getCharacteristic(this.platform.Characteristic.Active)
+      .onGet(this.getFanActive.bind(this))
+      .onSet(this.setFanActive.bind(this));
+
+    this.fanService.getCharacteristic(this.platform.Characteristic.CurrentFanState)
+      .onGet(this.getCurrentFanState.bind(this));
   }
 
   private setupScheduleSwitch(): void {
@@ -227,6 +259,16 @@ export class NestThermostatAccessory {
     this.humidityService.updateCharacteristic(
       this.platform.Characteristic.CurrentRelativeHumidity,
       this.state.humidity,
+    );
+
+    this.fanService?.updateCharacteristic(
+      this.platform.Characteristic.Active,
+      this.getFanActive(),
+    );
+
+    this.fanService?.updateCharacteristic(
+      this.platform.Characteristic.CurrentFanState,
+      this.getCurrentFanState(),
     );
   }
 
@@ -385,5 +427,32 @@ export class NestThermostatAccessory {
 
   getCurrentHumidity(): CharacteristicValue {
     return this.state.humidity;
+  }
+
+  getFanActive(): CharacteristicValue {
+    return this.state.fanActive
+      ? this.platform.Characteristic.Active.ACTIVE
+      : this.platform.Characteristic.Active.INACTIVE;
+  }
+
+  getCurrentFanState(): CharacteristicValue {
+    return this.state.fanRunning
+      ? this.platform.Characteristic.CurrentFanState.BLOWING_AIR
+      : this.platform.Characteristic.CurrentFanState.INACTIVE;
+  }
+
+  async setFanActive(value: CharacteristicValue): Promise<void> {
+    const active = value === this.platform.Characteristic.Active.ACTIVE;
+    this.platform.log.info(`Setting ${this.state.name} fan to ${active ? 'on' : 'auto'}`);
+
+    try {
+      await this.apiClient.setFanActive(this.state.deviceId, active);
+      this.state.fanActive = active;
+    } catch (error) {
+      this.platform.log.error('Failed to set fan mode:', error);
+      throw new this.platform.api.hap.HapStatusError(
+        this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

- expose a HomeKit `Fanv2` service for self-hosted Nest thermostats that report fan capability
- map HomeKit `Active` to No Longer Evil's `set_fan` command (`on` / `auto`)
- report actual blower operation independently through `CurrentFanState`
- leave hosted-API fan control disabled until that API exposes a verified fan command

## Behavior

The fan tile represents the Nest fan-timer/manual request. Setting it to **On** starts the server-configured fan duration; setting it to **Off** cancels that request and returns fan control to Auto. `CurrentFanState` continues to reflect the thermostat's actual `hvac.fan` state, so a blower running because of HVAC demand or an existing continuous-fan configuration is not mistaken for a manual HomeKit request.

## Validation

- `npm run lint`
- `npm run build`
- installed the packaged branch on Homebridge 2.2.1 with the plugin running as a child bridge
- verified discovery of a self-hosted Gen 2 Nest with fan capability
- verified HomeKit **On** activates the No Longer Evil fan timer
- verified HomeKit **Off** cancels the timer and returns fan control to Auto
- verified actual blower operation remains independently represented when no manual HomeKit fan request is active
